### PR TITLE
Delete multiple inheritance in test_center.py

### DIFF
--- a/centers/tests/models/test_center.py
+++ b/centers/tests/models/test_center.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from django.test import TestCase
-
 # Model
 from centers.models.center import Center
 
@@ -13,7 +11,7 @@ from centers.utils.center_hashids import get_encoded_center_hashid
 from centers.utils.center_hashids import get_center_hashids_object
 
 
-class CenterTest(RegionAllLayerTest, TestCase):
+class CenterTest(RegionAllLayerTest):
 
     def setUp(self):
         self.hashids = get_center_hashids_object()


### PR DESCRIPTION
현재 CenterTest의 검색 순서입니다.
```
<class centers.tests.models.test_center.CenterTest>, 
<class centers.tests.models.test_region.RegionAllLayerTest>, 
<class django.test.testcases.TestCase>, 
<class django.test.testcases.TransactionTestCase>, 
<class django.test.testcases.SimpleTestCase>, 
<class unittest.case.TestCase>, 
<type object>
```